### PR TITLE
build: derive version from git tag; publish on GitHub Release

### DIFF
--- a/.github/workflows/create_artifacts_and_publish.yaml
+++ b/.github/workflows/create_artifacts_and_publish.yaml
@@ -1,32 +1,40 @@
-# Builds with uv and publishes to PyPI via trusted publishing (OIDC) when a
-# version tag is pushed. See: https://docs.pypi.org/trusted-publishers/
-#
-# Actions are pinned to commit SHAs (with a version comment); Dependabot's
-# github-actions updater keeps them current.
+# Publishes to PyPI when a GitHub Release is created and published.
+# Trigger: manually create a release in GitHub UI, which allows review
+# of release notes before anything is pushed to PyPI.
+# See: https://docs.pypi.org/trusted-publishers/using-a-publisher/
 
 name: Upload Python Package
 
 on:
-  push:
-    tags:
-    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
-
-permissions:
-  contents: read
+  release:
+    types: [published]
 
 jobs:
   release-build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      attestations: write # for build provenance attestation
+      id-token: write # to mint OIDC token for attestation
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          python-version: "3.12"
+          fetch-depth: 0 # setuptools-scm needs full history and tags for versioning
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
       - name: Build package
-        run: uv build
-      - name: Publish artifacts
+        run: python -m build
+      - name: Attest generated files
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: dist/
+      - name: Upload release distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-dists
@@ -34,17 +42,14 @@ jobs:
 
   pypi-publish:
     runs-on: ubuntu-latest
+    needs: [release-build]
 
-    needs:
-      - release-build
-
-    permissions:
-      id-token: write # mandatory for trusted publishing
-
-    # Dedicated environments with protections for publishing are strongly recommended.
     environment:
       name: pypi
       url: https://pypi.org/p/argocli
+
+    permissions:
+      id-token: write # mandatory for trusted publishing
 
     steps:
       - name: Retrieve release distributions
@@ -55,33 +60,3 @@ jobs:
 
       - name: Publish release distributions to PyPI
         uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
-
-  github-release:
-    name: Create a release with artifacts
-    needs:
-    - pypi-publish
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write  # IMPORTANT: mandatory for making GitHub Releases
-      id-token: write  # IMPORTANT: mandatory for sigstore
-
-    steps:
-      - name: Retrieve release distributions
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: release-dists
-          path: dist/
-
-      - name: Verify distribution files
-        run: |
-          ls -la dist/
-          test -n "$(find dist -name '*.whl')" || (echo "Wheel file missing" && exit 1)
-          test -n "$(find dist -name '*.tar.gz')" || (echo "Source distribution missing" && exit 1)
-
-      - name: Create release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          files: dist/*
-          generate_release_notes: true
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create_artifacts_and_publish.yaml
+++ b/.github/workflows/create_artifacts_and_publish.yaml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0 # setuptools-scm needs full history and tags for versioning
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.x"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ test = [
 argocli = "argocli:main"
 
 [build-system]
-requires = ["setuptools>=61.0", "setuptools-scm"]
+requires = ["setuptools>=61.0", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "argocli"
-version = "0.4.0"
+dynamic = ["version"]
 description = "A command-line interface for Argo Workflows"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -18,6 +18,19 @@ test = [
 
 [project.scripts]
 argocli = "argocli:main"
+
+[build-system]
+requires = ["setuptools>=61.0", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["argocli*"]
+
+[tool.setuptools.package-data]
+"argocli" = ["config/*.yaml"]
 
 [tool.uv]
 package = true

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,6 @@ wheels = [
 
 [[package]]
 name = "argocli"
-version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cac-core" },


### PR DESCRIPTION
## Why

The `v0.5.0` release failed at the PyPI upload step:

```
400 File already exists ('argocli-0.4.0-py3-none-any.whl' ...)
```

`uv build` reads the version from `pyproject.toml`, which still said `0.4.0`. Pushing the `v0.5.0` tag never changed that, so the build produced `argocli-0.4.0` artifacts and PyPI rejected the re-upload of an already-published version.

## What

Mirrors the sibling **cac-jira** publishing setup so the tag becomes the single source of truth:

- **`pyproject.toml`** — `version = "0.4.0"` → `dynamic = ["version"]` via `setuptools-scm`. The version is now derived from the git tag, so it can't fall out of sync. Adds the setuptools build backend, package discovery, and `config/*.yaml` package data.
- **`.github/workflows/create_artifacts_and_publish.yaml`** — trigger on `release: [published]` instead of tag push, so release notes are reviewed in the UI before anything is uploaded. Builds with `python -m build` + build-provenance attestation, and drops the now-redundant separate `github-release` job.
- Adds `fetch-depth: 0` to checkout so `setuptools-scm` can see the tag history (minor deviation from the cac-jira copy).
- `uv.lock` — drops the now-obsolete static `version` entry for the editable package.

## Releasing after this merges

1. Merge to `main`.
2. GitHub → Releases → **Draft a new release**, tag `v0.5.0` on the merge commit, review notes, **Publish**.
3. The workflow fires, `setuptools-scm` derives `0.5.0` from the tag, and it publishes to PyPI.

## Test plan

- `uv run pytest` — 26 passed
- `uv build` — produces correctly versioned artifacts from the tag/commit